### PR TITLE
Fix dmenu JSONL identity by returning selected index instead of title

### DIFF
--- a/crates/heats-core/src/source/mod.rs
+++ b/crates/heats-core/src/source/mod.rs
@@ -74,6 +74,8 @@ pub enum IconData {
 /// An item displayed in the fuzzy finder (daemon internal UI type)
 #[derive(Debug, Clone)]
 pub struct SourceItem {
+    /// Unique identifier within a session (e.g. original line index for dmenu items)
+    pub id: Option<usize>,
     /// Display title (e.g. app name)
     pub title: String,
     /// Optional subtitle (e.g. path)

--- a/crates/heats-daemon/src/app.rs
+++ b/crates/heats-daemon/src/app.rs
@@ -36,7 +36,7 @@ pub struct State {
     /// Loaded items with action resolution metadata
     loaded_items: Vec<LoadedItem>,
 
-    /// Active dmenu session response channel (returns selected index)
+    /// Active dmenu session response channel (returns selected item's ID)
     dmenu_tx: Option<oneshot::Sender<Option<usize>>>,
     /// Whether current session is dmenu (external items) vs built-in
     is_dmenu_session: bool,
@@ -192,9 +192,9 @@ impl State {
                 Task::none()
             }
             Message::Execute => {
-                if self.results.get(self.selected).is_some() {
+                if let Some(item) = self.results.get(self.selected) {
                     if self.is_dmenu_session {
-                        self.send_dmenu_response(Some(self.selected));
+                        self.send_dmenu_response(item.id);
                     }
                 }
                 // Capture action info before hide() clears state
@@ -209,9 +209,9 @@ impl State {
             }
             Message::SelectAndExecute(index) => {
                 self.selected = index;
-                if self.results.get(index).is_some() {
+                if let Some(item) = self.results.get(index) {
                     if self.is_dmenu_session {
-                        self.send_dmenu_response(Some(index));
+                        self.send_dmenu_response(item.id);
                     }
                 }
                 let action = self.pending_action(index);

--- a/crates/heats-daemon/src/command.rs
+++ b/crates/heats-daemon/src/command.rs
@@ -47,6 +47,7 @@ pub async fn load_from_providers(
     while let Some(Ok((provider_name, items))) = set.join_next().await {
         for (dmenu_item, icon) in items {
             let source_item = SourceItem {
+                id: None,
                 title: dmenu_item.title.clone(),
                 subtitle: dmenu_item.subtitle.clone(),
                 exec_path: dmenu_item.get_field("data"),


### PR DESCRIPTION
## Summary
- Change dmenu session response type from `String` (title) to `usize` (selected index)
- Use `index_map` in ipc_server to translate the selected index back to the original raw line
- Eliminate fragile title-based reverse lookup that caused misidentification of items with duplicate titles

## Test plan
- [x] `cargo build` — builds successfully
- [x] `cargo clippy` — no new warnings
- [ ] `echo -e "foo\nbar\nbaz" | ./target/debug/heats` — verify text format works correctly

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)