### PR TITLE
Extract helper methods and reduce duplication in app.rs

### DIFF
--- a/crates/heats-client/src/lib.rs
+++ b/crates/heats-client/src/lib.rs
@@ -29,10 +29,11 @@ pub async fn send_and_receive(
     let (reader, mut writer) = stream.into_split();
 
     // Send context line
-    let context = match format {
-        IpcFormat::Text => r#"{"format":"text"}"#,
-        IpcFormat::Jsonl => r#"{"format":"jsonl"}"#,
+    let format_str = match format {
+        IpcFormat::Text => heats_core::ipc::FORMAT_TEXT,
+        IpcFormat::Jsonl => heats_core::ipc::FORMAT_JSONL,
     };
+    let context = format!(r#"{{"format":"{}"}}"#, format_str);
     writer.write_all(context.as_bytes()).await?;
     writer.write_all(b"\n").await?;
 

--- a/crates/heats-core/src/config.rs
+++ b/crates/heats-core/src/config.rs
@@ -79,6 +79,15 @@ fn default_field() -> String {
     "data".to_string()
 }
 
+/// Display bounds in CG coordinates (origin at top-left of main display).
+#[derive(Debug, Clone, Copy)]
+pub struct DisplayBounds {
+    pub x: f64,
+    pub y: f64,
+    pub width: f64,
+    pub height: f64,
+}
+
 /// Window management mode
 #[derive(Debug, Clone, Deserialize, PartialEq)]
 #[serde(rename_all = "lowercase")]
@@ -166,8 +175,7 @@ impl Default for WindowConfig {
 }
 
 pub fn load_from(path: &std::path::Path) -> Config {
-    let path = path.to_path_buf();
-    load_path(&path)
+    load_path(path)
 }
 
 pub fn load() -> Config {
@@ -175,7 +183,7 @@ pub fn load() -> Config {
     load_path(&path)
 }
 
-fn load_path(path: &PathBuf) -> Config {
+fn load_path(path: &std::path::Path) -> Config {
     if !path.exists() {
         tracing::info!("No config file found at {:?}, using defaults", path);
         return Config::default();

--- a/crates/heats-core/src/ipc/mod.rs
+++ b/crates/heats-core/src/ipc/mod.rs
@@ -1,5 +1,9 @@
 use std::path::PathBuf;
 
+/// IPC format identifiers used in the context line between client and daemon.
+pub const FORMAT_TEXT: &str = "text";
+pub const FORMAT_JSONL: &str = "jsonl";
+
 /// Resolve the runtime directory for IPC files.
 /// Uses $XDG_RUNTIME_DIR, falling back to /tmp/heats-{uid}.
 /// Creates the directory if it does not exist.

--- a/crates/heats-core/src/platform/macos.rs
+++ b/crates/heats-core/src/platform/macos.rs
@@ -339,19 +339,3 @@ fn fallback_main_display() -> DisplayBounds {
         height: b.size.height,
     }
 }
-
-#[allow(dead_code)]
-fn mouse_position() -> (f64, f64) {
-    let source = match core_graphics::event_source::CGEventSource::new(
-        core_graphics::event_source::CGEventSourceStateID::CombinedSessionState,
-    ) {
-        Ok(s) => s,
-        Err(_) => return (0.0, 0.0),
-    };
-    let event = match core_graphics::event::CGEvent::new(source) {
-        Ok(e) => e,
-        Err(_) => return (0.0, 0.0),
-    };
-    let point = event.location();
-    (point.x, point.y)
-}

--- a/crates/heats-core/src/platform/macos.rs
+++ b/crates/heats-core/src/platform/macos.rs
@@ -1,5 +1,6 @@
 use std::process::Command;
 
+use crate::config::DisplayBounds;
 use core_graphics::display::CGDisplay;
 use objc::runtime::Object;
 use objc::{class, msg_send, sel, sel_impl, Encode, Encoding};
@@ -88,7 +89,7 @@ pub fn bundle_path_for_pid(pid: i32) -> Option<String> {
 
 /// Get the bounds of the display that has keyboard focus (NSScreen.mainScreen).
 /// NSScreen.mainScreen returns the screen containing the window currently receiving keyboard events.
-pub fn focused_display_bounds() -> (f64, f64, f64, f64) {
+pub fn focused_display_bounds() -> DisplayBounds {
     unsafe {
         let main_screen: *mut Object = msg_send![class!(NSScreen), mainScreen];
         if !main_screen.is_null() {
@@ -99,12 +100,12 @@ pub fn focused_display_bounds() -> (f64, f64, f64, f64) {
                     "focused_display_bounds: NSScreen.mainScreen → CGDisplayID={}, bounds=({}, {}, {}, {})",
                     display_id, bounds.origin.x, bounds.origin.y, bounds.size.width, bounds.size.height
                 );
-                return (
-                    bounds.origin.x,
-                    bounds.origin.y,
-                    bounds.size.width,
-                    bounds.size.height,
-                );
+                return DisplayBounds {
+                    x: bounds.origin.x,
+                    y: bounds.origin.y,
+                    width: bounds.size.width,
+                    height: bounds.size.height,
+                };
             }
         }
     }
@@ -129,7 +130,7 @@ unsafe fn screen_display_id(screen: *mut Object) -> Option<u32> {
 
 /// Get the bounds of a display by name (substring match).
 /// Returns CG coordinates (origin at top-left of main display).
-pub fn display_bounds_by_name(name: &str) -> (f64, f64, f64, f64) {
+pub fn display_bounds_by_name(name: &str) -> DisplayBounds {
     let screens = list_screens();
     let name_lower = name.to_lowercase();
 
@@ -146,12 +147,12 @@ pub fn display_bounds_by_name(name: &str) -> (f64, f64, f64, f64) {
                 bounds.size.width,
                 bounds.size.height
             );
-            return (
-                bounds.origin.x,
-                bounds.origin.y,
-                bounds.size.width,
-                bounds.size.height,
-            );
+            return DisplayBounds {
+                x: bounds.origin.x,
+                y: bounds.origin.y,
+                width: bounds.size.width,
+                height: bounds.size.height,
+            };
         }
     }
 
@@ -273,12 +274,10 @@ unsafe fn find_heats_window() -> Option<*mut Object> {
 
 /// Show the Heats window at the center of the given display (CG coordinates).
 /// Uses NSWindow.setFrame + makeKeyAndOrderFront (like Raycast).
-pub fn native_show_window(display: &(f64, f64, f64, f64), win_w: f64, win_h: f64) {
-    let (disp_x, disp_y, disp_w, disp_h) = *display;
-
+pub fn native_show_window(display: &DisplayBounds, win_w: f64, win_h: f64) {
     // Center position in CG coordinates (origin = top-left of main display, y down)
-    let cg_x = disp_x + (disp_w - win_w) / 2.0;
-    let cg_y = disp_y + (disp_h - win_h) / 3.0;
+    let cg_x = display.x + (display.width - win_w) / 2.0;
+    let cg_y = display.y + (display.height - win_h) / 3.0;
 
     // Convert CG → AppKit coordinates (origin = bottom-left of main display, y up)
     let main_height = CGDisplay::main().bounds().size.height;
@@ -330,10 +329,15 @@ pub fn native_hide_window() {
     }
 }
 
-fn fallback_main_display() -> (f64, f64, f64, f64) {
+fn fallback_main_display() -> DisplayBounds {
     let main = CGDisplay::main();
     let b = main.bounds();
-    (b.origin.x, b.origin.y, b.size.width, b.size.height)
+    DisplayBounds {
+        x: b.origin.x,
+        y: b.origin.y,
+        width: b.size.width,
+        height: b.size.height,
+    }
 }
 
 #[allow(dead_code)]

--- a/crates/heats-core/src/source/mod.rs
+++ b/crates/heats-core/src/source/mod.rs
@@ -1,6 +1,7 @@
 pub mod applications;
 pub mod windows;
 
+use std::borrow::Cow;
 use std::sync::Arc;
 
 /// JSONL protocol type: the schema for source command → daemon communication
@@ -17,44 +18,50 @@ pub struct DmenuItem {
 
 impl DmenuItem {
     /// Get a field value by dot-separated path (e.g. "title", "data.pid")
-    pub fn get_field(&self, field: &str) -> String {
+    pub fn get_field(&self, field: &str) -> Cow<'_, str> {
         match field {
-            "title" => self.title.clone(),
-            "subtitle" => self.subtitle.clone().unwrap_or_default(),
-            "icon_path" => self.icon_path.clone().unwrap_or_default(),
+            "title" => Cow::Borrowed(&self.title),
+            "subtitle" => match &self.subtitle {
+                Some(s) => Cow::Borrowed(s),
+                None => Cow::Borrowed(""),
+            },
+            "icon_path" => match &self.icon_path {
+                Some(s) => Cow::Borrowed(s),
+                None => Cow::Borrowed(""),
+            },
             _ if field.starts_with("data") => {
                 let data = match &self.data {
                     Some(v) => v,
-                    None => return self.title.clone(),
+                    None => return Cow::Borrowed(&self.title),
                 };
                 if field == "data" {
-                    value_to_string(data)
+                    value_to_cow(data)
                 } else if let Some(rest) = field.strip_prefix("data.") {
                     let mut current = data;
                     for key in rest.split('.') {
                         match current.get(key) {
                             Some(v) => current = v,
-                            None => return String::new(),
+                            None => return Cow::Borrowed(""),
                         }
                     }
-                    value_to_string(current)
+                    value_to_cow(current)
                 } else {
-                    self.title.clone()
+                    Cow::Borrowed(&self.title)
                 }
             }
-            _ => self.title.clone(),
+            _ => Cow::Borrowed(&self.title),
         }
     }
 }
 
-/// Convert a JSON value to a plain string for action arguments
-fn value_to_string(v: &serde_json::Value) -> String {
+/// Convert a JSON value to a Cow string for action arguments
+fn value_to_cow(v: &serde_json::Value) -> Cow<'_, str> {
     match v {
-        serde_json::Value::String(s) => s.clone(),
-        serde_json::Value::Number(n) => n.to_string(),
-        serde_json::Value::Bool(b) => b.to_string(),
-        serde_json::Value::Null => String::new(),
-        other => other.to_string(),
+        serde_json::Value::String(s) => Cow::Borrowed(s),
+        serde_json::Value::Number(n) => Cow::Owned(n.to_string()),
+        serde_json::Value::Bool(b) => Cow::Owned(b.to_string()),
+        serde_json::Value::Null => Cow::Borrowed(""),
+        other => Cow::Owned(other.to_string()),
     }
 }
 

--- a/crates/heats-daemon/src/app.rs
+++ b/crates/heats-daemon/src/app.rs
@@ -14,8 +14,7 @@ use crate::ipc_server;
 use crate::keybinding::{self, KeyBinding};
 use crate::matcher::engine::Matcher;
 use crate::ui::{result_list, search_input, tab_bar, theme};
-use heats_core::config::Config;
-use heats_core::config::WindowMode;
+use heats_core::config::{Config, DisplayBounds, WindowMode};
 use heats_core::source::SourceItem;
 
 pub struct State {
@@ -31,7 +30,7 @@ pub struct State {
     /// Whether the launcher is currently shown
     visible: bool,
     /// Fixed display bounds (only used in Fixed mode)
-    fixed_display: (f64, f64, f64, f64),
+    fixed_display: DisplayBounds,
 
     _hotkey_manager: global_hotkey::GlobalHotKeyManager,
     hotkey_modes: Vec<(u32, String)>,
@@ -239,58 +238,10 @@ impl State {
                     Task::none()
                 }
             }
-            Message::Execute => {
-                let eval_count = self.eval_items.len();
-                if self.selected < eval_count {
-                    // Selected an evaluator result
-                    let eval_action = self.pending_eval_action(self.selected);
-                    let hide_task = self.hide();
-                    if let Some((config, dmenu_item)) = eval_action {
-                        command::run_action(&config, &dmenu_item);
-                    }
-                    return hide_task;
-                }
-
-                let adjusted = self.selected - eval_count;
-                if let Some(item) = self.results.get(adjusted) {
-                    if self.is_dmenu_session {
-                        self.send_dmenu_response(item.id);
-                    }
-                }
-                // Capture action info before hide() clears state
-                let action = self.pending_action(adjusted);
-                // Hide first so macOS deactivates Heats before the action
-                // activates the target app — avoids focus bounce-back
-                let hide_task = self.hide();
-                if let Some((provider, dmenu_item)) = action {
-                    command::execute_action(&provider, &dmenu_item);
-                }
-                hide_task
-            }
+            Message::Execute => self.execute_selected(),
             Message::SelectAndExecute(index) => {
                 self.selected = index;
-                let eval_count = self.eval_items.len();
-                if index < eval_count {
-                    let eval_action = self.pending_eval_action(index);
-                    let hide_task = self.hide();
-                    if let Some((config, dmenu_item)) = eval_action {
-                        command::run_action(&config, &dmenu_item);
-                    }
-                    return hide_task;
-                }
-
-                let adjusted = index - eval_count;
-                if let Some(item) = self.results.get(adjusted) {
-                    if self.is_dmenu_session {
-                        self.send_dmenu_response(item.id);
-                    }
-                }
-                let action = self.pending_action(adjusted);
-                let hide_task = self.hide();
-                if let Some((provider, dmenu_item)) = action {
-                    command::execute_action(&provider, &dmenu_item);
-                }
-                hide_task
+                self.execute_selected()
             }
             Message::ItemsLoaded(loaded_items) => {
                 // Ignore items while a dmenu session is active
@@ -304,9 +255,7 @@ impl State {
                 } else {
                     self.loaded_items.extend(loaded_items);
                 }
-                self.all_items = self.loaded_items.iter().map(|li| li.item.clone()).collect();
-                self.matcher.set_items(self.all_items.clone());
-                self.results = self.all_items.clone();
+                self.apply_loaded_items();
                 // No focus call here — WindowOpened already handled focus
                 Task::none()
             }
@@ -588,11 +537,7 @@ impl State {
             return None;
         }
         let selected_item = self.results.get(selected_index)?;
-        let loaded = self.loaded_items.iter().find(|li| {
-            li.item.title == selected_item.title
-                && li.item.source_name == selected_item.source_name
-                && li.item.exec_path == selected_item.exec_path
-        })?;
+        let loaded = self.find_loaded_item(selected_item)?;
         let provider = self.config.provider.get(&loaded.provider_name)?;
         Some((provider.clone(), loaded.dmenu_item.clone()))
     }
@@ -607,11 +552,7 @@ impl State {
             return None;
         }
         let selected_item = self.results.get(selected_index)?;
-        let loaded = self.loaded_items.iter().find(|li| {
-            li.item.title == selected_item.title
-                && li.item.source_name == selected_item.source_name
-                && li.item.exec_path == selected_item.exec_path
-        })?;
+        let loaded = self.find_loaded_item(selected_item)?;
         let provider = self.config.provider.get(&loaded.provider_name)?;
         let action_config = provider.actions.get(action_name)?;
         let field = action_config
@@ -698,36 +639,7 @@ impl State {
 
         self.visible = true;
 
-        // Split providers into cached (instant) and uncached (need async load)
-        let mut cached_items: Vec<LoadedItem> = Vec::new();
-        let mut uncached_names: Vec<String> = Vec::new();
-
-        for name in &provider_names {
-            if let Some(items) = self.provider_cache.get(name) {
-                cached_items.extend(items.clone());
-            } else {
-                uncached_names.push(name.clone());
-            }
-        }
-
-        // Pre-populate with cached items immediately
-        if !cached_items.is_empty() {
-            self.loaded_items = cached_items;
-            self.all_items = self.loaded_items.iter().map(|li| li.item.clone()).collect();
-            self.matcher.set_items(self.all_items.clone());
-            self.results = self.all_items.clone();
-        }
-
-        // Load uncached providers asynchronously (if any)
-        let load_task = if uncached_names.is_empty() {
-            Task::none()
-        } else {
-            let providers = self.config.provider.clone();
-            Task::perform(
-                async move { command::load_from_providers(&uncached_names, &providers).await },
-                Message::ItemsLoaded,
-            )
-        };
+        let load_task = self.load_providers_with_cache(&provider_names);
 
         match self.config.window.mode {
             WindowMode::Fixed => self.show_fixed(load_task),
@@ -814,13 +726,12 @@ impl State {
     // ---- Helpers ----
 
     fn center_on_display(
-        display: &(f64, f64, f64, f64),
+        display: &DisplayBounds,
         win_w: f32,
         win_h: f32,
     ) -> Point {
-        let (disp_x, disp_y, disp_w, disp_h) = *display;
-        let x = disp_x + (disp_w - win_w as f64) / 2.0;
-        let y = disp_y + (disp_h - win_h as f64) / 3.0;
+        let x = display.x + (display.width - win_w as f64) / 2.0;
+        let y = display.y + (display.height - win_h as f64) / 3.0;
         Point::new(x as f32, y as f32)
     }
 
@@ -857,33 +768,7 @@ impl State {
 
         // Load providers (cached first, then async)
         let provider_names = mode.providers.clone();
-        let mut cached_items: Vec<LoadedItem> = Vec::new();
-        let mut uncached_names: Vec<String> = Vec::new();
-
-        for name in &provider_names {
-            if let Some(items) = self.provider_cache.get(name) {
-                cached_items.extend(items.clone());
-            } else {
-                uncached_names.push(name.clone());
-            }
-        }
-
-        if !cached_items.is_empty() {
-            self.loaded_items = cached_items;
-            self.all_items = self.loaded_items.iter().map(|li| li.item.clone()).collect();
-            self.matcher.set_items(self.all_items.clone());
-            self.results = self.all_items.clone();
-        }
-
-        let load_task = if uncached_names.is_empty() {
-            Task::none()
-        } else {
-            let providers = self.config.provider.clone();
-            Task::perform(
-                async move { command::load_from_providers(&uncached_names, &providers).await },
-                Message::ItemsLoaded,
-            )
-        };
+        let load_task = self.load_providers_with_cache(&provider_names);
 
         // Refocus search input
         let focus_task = iced::widget::operation::focus(search_input::SEARCH_INPUT_ID);
@@ -915,6 +800,94 @@ impl State {
                 Some((binding, action_name.clone()))
             })
             .collect()
+    }
+
+    /// Build all_items from loaded_items, feed them into the matcher, and set results.
+    /// Used after loading items (from cache or async providers).
+    fn apply_loaded_items(&mut self) {
+        self.all_items = self.loaded_items.iter().map(|li| li.item.clone()).collect();
+        self.matcher.set_items(self.all_items.clone());
+        self.results = self.all_items.clone();
+    }
+
+    /// Find the LoadedItem matching a SourceItem by title + source_name + exec_path.
+    fn find_loaded_item(&self, item: &SourceItem) -> Option<&LoadedItem> {
+        self.loaded_items.iter().find(|li| {
+            li.item.title == item.title
+                && li.item.source_name == item.source_name
+                && li.item.exec_path == item.exec_path
+        })
+    }
+
+    /// Execute the currently selected item (shared logic for Execute and SelectAndExecute).
+    fn execute_selected(&mut self) -> Task<Message> {
+        let eval_count = self.eval_items.len();
+        if self.selected < eval_count {
+            let eval_action = self.pending_eval_action(self.selected);
+            let hide_task = self.hide();
+            if let Some((config, dmenu_item)) = eval_action {
+                command::run_action(&config, &dmenu_item);
+            }
+            return hide_task;
+        }
+
+        let adjusted = self.selected - eval_count;
+        if let Some(item) = self.results.get(adjusted) {
+            if self.is_dmenu_session {
+                self.send_dmenu_response(item.id);
+            }
+        }
+        let action = self.pending_action(adjusted);
+        let hide_task = self.hide();
+        if let Some((provider, dmenu_item)) = action {
+            command::execute_action(&provider, &dmenu_item);
+        }
+        hide_task
+    }
+
+    /// Split providers into cached (instant) and uncached (need async load),
+    /// populate loaded_items with cached items, and return a Task for uncached providers.
+    fn load_providers_with_cache(&mut self, provider_names: &[String]) -> Task<Message> {
+        let mut cached_items: Vec<LoadedItem> = Vec::new();
+        let mut uncached_names: Vec<String> = Vec::new();
+
+        for name in provider_names {
+            if let Some(items) = self.provider_cache.get(name) {
+                cached_items.extend(items.clone());
+            } else {
+                uncached_names.push(name.clone());
+            }
+        }
+
+        if !cached_items.is_empty() {
+            self.loaded_items = cached_items;
+            self.apply_loaded_items();
+        }
+
+        if uncached_names.is_empty() {
+            Task::none()
+        } else {
+            let providers = self.config.provider.clone();
+            Task::perform(
+                async move { command::load_from_providers(&uncached_names, &providers).await },
+                Message::ItemsLoaded,
+            )
+        }
+    }
+
+    /// Create a cache load Task for a single provider.
+    fn cache_load_task(name: String, provider: &heats_core::config::ProviderConfig) -> Task<Message> {
+        let name_for_msg = name.clone();
+        let providers = HashMap::from([(name.clone(), provider.clone())]);
+        Task::perform(
+            async move {
+                command::load_from_providers(&[name], &providers).await
+            },
+            move |items| Message::CacheUpdated {
+                provider_name: name_for_msg,
+                items,
+            },
+        )
     }
 
     fn reset_state(&mut self) {
@@ -950,20 +923,7 @@ impl State {
             .provider
             .iter()
             .filter(|(_, p)| p.cache_interval.is_some())
-            .map(|(name, p)| {
-                let name = name.clone();
-                let name_for_msg = name.clone();
-                let providers = HashMap::from([(name.clone(), p.clone())]);
-                Task::perform(
-                    async move {
-                        command::load_from_providers(&[name], &providers).await
-                    },
-                    move |items| Message::CacheUpdated {
-                        provider_name: name_for_msg,
-                        items,
-                    },
-                )
-            })
+            .map(|(name, p)| Self::cache_load_task(name.clone(), p))
             .collect();
 
         if tasks.is_empty() {
@@ -987,25 +947,9 @@ impl State {
                     .get(name)
                     .map(|t| now.duration_since(*t) >= interval)
                     .unwrap_or(true);
-                if is_stale {
-                    Some((name.clone(), p.clone()))
-                } else {
-                    None
-                }
+                if is_stale { Some((name, p)) } else { None }
             })
-            .map(|(name, p)| {
-                let name_for_msg = name.clone();
-                let providers = HashMap::from([(name.clone(), p)]);
-                Task::perform(
-                    async move {
-                        command::load_from_providers(&[name], &providers).await
-                    },
-                    move |items| Message::CacheUpdated {
-                        provider_name: name_for_msg,
-                        items,
-                    },
-                )
-            })
+            .map(|(name, p)| Self::cache_load_task(name.clone(), p))
             .collect();
 
         if tasks.is_empty() {

--- a/crates/heats-daemon/src/app.rs
+++ b/crates/heats-daemon/src/app.rs
@@ -749,25 +749,17 @@ impl State {
             return Task::none();
         }
 
-        self.current_mode_index = Some(new_index);
+        // Read mode data before reset_state() borrows self mutably
         let mode = &self.config.mode[new_index];
-
-        // Reset query and results
-        self.query.clear();
-        self.selected = 0;
-        self.all_items.clear();
-        self.results.clear();
-        self.loaded_items.clear();
-        self.matcher = Matcher::new();
-        self.eval_items.clear();
-        self.eval_generation = 0;
-
-        // Set evaluators and keybindings for new mode
-        self.active_evaluators = mode.evaluators.clone();
-        self.active_keybindings = Self::parse_mode_keybindings(mode);
-
-        // Load providers (cached first, then async)
+        let evaluators = mode.evaluators.clone();
+        let keybindings = Self::parse_mode_keybindings(mode);
         let provider_names = mode.providers.clone();
+
+        // Reset state, then configure for the new mode
+        self.reset_state();
+        self.current_mode_index = Some(new_index);
+        self.active_evaluators = evaluators;
+        self.active_keybindings = keybindings;
         let load_task = self.load_providers_with_cache(&provider_names);
 
         // Refocus search input
@@ -893,6 +885,7 @@ impl State {
     fn reset_state(&mut self) {
         self.query.clear();
         self.selected = 0;
+        self.all_items.clear();
         self.results.clear();
         self.loaded_items.clear();
         self.matcher.update_query("");

--- a/crates/heats-daemon/src/command.rs
+++ b/crates/heats-daemon/src/command.rs
@@ -51,7 +51,7 @@ pub async fn load_from_providers(
                 id: None,
                 title: dmenu_item.title.clone(),
                 subtitle: dmenu_item.subtitle.clone(),
-                exec_path: dmenu_item.get_field("data"),
+                exec_path: dmenu_item.get_field("data").into_owned(),
                 source_name: provider_name.clone(),
                 icon,
             };

--- a/crates/heats-daemon/src/command.rs
+++ b/crates/heats-daemon/src/command.rs
@@ -188,21 +188,28 @@ async fn run_pipeline(
         children.push(child);
     }
 
-    // Read all output from the last command
-    let output = if let Some(stdout) = prev_stdout {
-        let reader = BufReader::new(stdout);
-        let mut lines = reader.lines();
-        let mut output = String::new();
-        while let Ok(Some(line)) = lines.next_line().await {
-            output.push_str(&line);
-            output.push('\n');
-        }
-        output
-    } else {
-        String::new()
-    };
+    let output = read_all_output(prev_stdout).await;
+    wait_all_children(children).await?;
+    Ok(output)
+}
 
-    // Wait for all children and check exit status
+/// Read all lines from a pipeline's final stdout.
+async fn read_all_output(stdout: Option<tokio::process::ChildStdout>) -> String {
+    let Some(stdout) = stdout else {
+        return String::new();
+    };
+    let reader = BufReader::new(stdout);
+    let mut lines = reader.lines();
+    let mut output = String::new();
+    while let Ok(Some(line)) = lines.next_line().await {
+        output.push_str(&line);
+        output.push('\n');
+    }
+    output
+}
+
+/// Wait for all child processes and check exit status.
+async fn wait_all_children(children: Vec<tokio::process::Child>) -> Result<(), String> {
     for mut child in children {
         let status = child
             .wait()
@@ -212,8 +219,7 @@ async fn run_pipeline(
             return Err(format!("Pipeline command exited with {}", status));
         }
     }
-
-    Ok(output)
+    Ok(())
 }
 
 /// Kill all child processes in a pipeline.

--- a/crates/heats-daemon/src/evaluator.rs
+++ b/crates/heats-daemon/src/evaluator.rs
@@ -49,7 +49,7 @@ pub async fn run_evaluators(
                 id: None,
                 title: dmenu_item.title.clone(),
                 subtitle: dmenu_item.subtitle.clone(),
-                exec_path: dmenu_item.get_field("data"),
+                exec_path: dmenu_item.get_field("data").into_owned(),
                 source_name: format!("eval:{eval_name}"),
                 icon: None,
             };

--- a/crates/heats-daemon/src/hotkey.rs
+++ b/crates/heats-daemon/src/hotkey.rs
@@ -4,6 +4,7 @@ use iced::futures::SinkExt;
 use iced::stream::channel;
 use iced::Subscription;
 
+use crate::key_parse::{self, ModifierKind};
 use heats_core::config::ModeConfig;
 
 /// Message emitted by the hotkey subscription
@@ -84,12 +85,12 @@ fn parse_hotkey_str(s: &str) -> (Modifiers, Code) {
 
     let mut mods = Modifiers::empty();
     for part in mod_parts {
-        match part.trim().to_lowercase().as_str() {
-            "cmd" | "super" | "command" | "meta" => mods |= Modifiers::SUPER,
-            "ctrl" | "control" => mods |= Modifiers::CONTROL,
-            "alt" | "option" => mods |= Modifiers::ALT,
-            "shift" => mods |= Modifiers::SHIFT,
-            _ => tracing::warn!("Unknown modifier: {}", part),
+        match key_parse::parse_modifier(part.trim()) {
+            Some(ModifierKind::Super) => mods |= Modifiers::SUPER,
+            Some(ModifierKind::Ctrl) => mods |= Modifiers::CONTROL,
+            Some(ModifierKind::Alt) => mods |= Modifiers::ALT,
+            Some(ModifierKind::Shift) => mods |= Modifiers::SHIFT,
+            None => tracing::warn!("Unknown modifier: {}", part),
         }
     }
 

--- a/crates/heats-daemon/src/ipc_server.rs
+++ b/crates/heats-daemon/src/ipc_server.rs
@@ -84,7 +84,7 @@ fn dmenu_stream() -> impl iced::futures::Stream<Item = Message> {
                         }
                     };
 
-                let is_jsonl = format == "jsonl";
+                let is_jsonl = format == heats_core::ipc::FORMAT_JSONL;
 
                 // Read remaining lines
                 let mut raw_lines = Vec::new();

--- a/crates/heats-daemon/src/ipc_server.rs
+++ b/crates/heats-daemon/src/ipc_server.rs
@@ -134,7 +134,7 @@ fn dmenu_stream() -> impl iced::futures::Stream<Item = Message> {
                                     id: Some(idx),
                                     title: di.title.clone(),
                                     subtitle: di.subtitle.clone(),
-                                    exec_path: di.get_field("data"),
+                                    exec_path: di.get_field("data").into_owned(),
                                     source_name: "dmenu".to_string(),
                                     icon: None,
                                 }),

--- a/crates/heats-daemon/src/key_parse.rs
+++ b/crates/heats-daemon/src/key_parse.rs
@@ -1,0 +1,21 @@
+/// Common modifier kind shared between global_hotkey and iced keyboard types.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ModifierKind {
+    Super,
+    Ctrl,
+    Alt,
+    Shift,
+}
+
+/// Parse a modifier name string into a ModifierKind.
+/// Accepts common aliases: "cmd"/"super"/"command"/"meta", "ctrl"/"control",
+/// "alt"/"option", "shift".
+pub fn parse_modifier(s: &str) -> Option<ModifierKind> {
+    match s.to_lowercase().as_str() {
+        "cmd" | "super" | "command" | "meta" => Some(ModifierKind::Super),
+        "ctrl" | "control" => Some(ModifierKind::Ctrl),
+        "alt" | "option" => Some(ModifierKind::Alt),
+        "shift" => Some(ModifierKind::Shift),
+        _ => None,
+    }
+}

--- a/crates/heats-daemon/src/keybinding.rs
+++ b/crates/heats-daemon/src/keybinding.rs
@@ -1,5 +1,7 @@
 use iced::keyboard;
 
+use crate::key_parse::{self, ModifierKind};
+
 /// A parsed keybinding (modifier keys + key)
 #[derive(Debug, Clone)]
 pub struct KeyBinding {
@@ -20,12 +22,12 @@ pub fn parse(s: &str) -> Option<KeyBinding> {
     let key_str = parts.last()?;
 
     for &part in &parts[..parts.len() - 1] {
-        match part.to_lowercase().as_str() {
-            "alt" | "option" => modifiers |= keyboard::Modifiers::ALT,
-            "ctrl" | "control" => modifiers |= keyboard::Modifiers::CTRL,
-            "shift" => modifiers |= keyboard::Modifiers::SHIFT,
-            "cmd" | "super" | "command" => modifiers |= keyboard::Modifiers::LOGO,
-            _ => return None,
+        match key_parse::parse_modifier(part) {
+            Some(ModifierKind::Super) => modifiers |= keyboard::Modifiers::LOGO,
+            Some(ModifierKind::Ctrl) => modifiers |= keyboard::Modifiers::CTRL,
+            Some(ModifierKind::Alt) => modifiers |= keyboard::Modifiers::ALT,
+            Some(ModifierKind::Shift) => modifiers |= keyboard::Modifiers::SHIFT,
+            None => return None,
         }
     }
 

--- a/crates/heats-daemon/src/main.rs
+++ b/crates/heats-daemon/src/main.rs
@@ -4,6 +4,7 @@ mod evaluator;
 mod hotkey;
 mod icon;
 mod ipc_server;
+mod key_parse;
 mod keybinding;
 mod matcher;
 mod ui;

--- a/crates/heats-daemon/src/ui/result_list.rs
+++ b/crates/heats-daemon/src/ui/result_list.rs
@@ -57,26 +57,7 @@ pub fn view<'a>(
             name.into()
         };
 
-        let row_content: Element<'a, Message> = match &item.icon {
-            Some(IconData::Rgba {
-                width,
-                height,
-                pixels,
-            }) => {
-                let handle =
-                    image::Handle::from_rgba(*width, *height, pixels.as_ref().clone());
-                let icon = image(handle).width(24).height(24);
-                row![icon, text_column]
-                    .spacing(8)
-                    .align_y(iced::Alignment::Center)
-                    .into()
-            }
-            Some(IconData::Text(s)) => row![text(s).size(20), text_column]
-                .spacing(8)
-                .align_y(iced::Alignment::Center)
-                .into(),
-            None => text_column,
-        };
+        let row_content = build_icon_row(text_column, &item.icon);
 
         let row = container(row_content)
             .padding(Padding::from([6, 12]))
@@ -89,4 +70,30 @@ pub fn view<'a>(
     }
 
     rows.into()
+}
+
+/// Combine icon (if any) with the text column into a single row element.
+fn build_icon_row<'a>(
+    text_column: Element<'a, Message>,
+    icon: &'a Option<IconData>,
+) -> Element<'a, Message> {
+    match icon {
+        Some(IconData::Rgba {
+            width,
+            height,
+            pixels,
+        }) => {
+            let handle = image::Handle::from_rgba(*width, *height, pixels.as_ref().clone());
+            let icon = image(handle).width(24).height(24);
+            row![icon, text_column]
+                .spacing(8)
+                .align_y(iced::Alignment::Center)
+                .into()
+        }
+        Some(IconData::Text(s)) => row![text(s).size(20), text_column]
+            .spacing(8)
+            .align_y(iced::Alignment::Center)
+            .into(),
+        None => text_column,
+    }
 }


### PR DESCRIPTION
## Summary
- Extract 5 helper methods in `app.rs` to eliminate duplicated code patterns (1017 → 961 lines): `apply_loaded_items()`, `find_loaded_item()`, `execute_selected()`, `load_providers_with_cache()`, `cache_load_task()`
- Change `DmenuItem::get_field()` return type from `String` to `Cow<str>` to avoid unnecessary allocations on borrowed field access
- Replace `(f64, f64, f64, f64)` display bounds tuple with typed `DisplayBounds` struct
- Change `load_path(&PathBuf)` to `load_path(&Path)` and remove redundant `to_path_buf()`

## Test plan
- [x] `cargo build` passes
- [x] `cargo clippy` passes (no new warnings)
- [x] `cargo test` passes
- [ ] Manual test: launcher open/close, mode switching, action execution, clipboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)